### PR TITLE
Invoke code refs for literal values

### DIFF
--- a/lib/Bread/Board/Declare/Meta/Role/Attribute.pm
+++ b/lib/Bread/Board/Declare/Meta/Role/Attribute.pm
@@ -212,8 +212,12 @@ around get_value => sub {
 
     my $val = $instance->get_service($self->name)->get;
 
-    $self->verify_against_type_constraint($val, instance => $instance)
-        if $self->has_type_constraint;
+    if ($self->has_type_constraint) {
+        $val = $self->type_constraint->coerce($val)
+            if $self->should_coerce;
+
+        $self->verify_against_type_constraint($val, instance => $instance);
+    }
 
     if ($self->should_auto_deref) {
         if (ref($val) eq 'ARRAY') {

--- a/lib/Bread/Board/Declare/Meta/Role/Attribute.pm
+++ b/lib/Bread/Board/Declare/Meta/Role/Attribute.pm
@@ -157,7 +157,9 @@ after attach_to_class => sub {
     elsif ($self->has_literal_value) {
         $service = Bread::Board::Declare::Literal->new(
             %params,
-            value => $self->literal_value,
+            value => (ref $self->literal_value
+                          ? $self->literal_value->($self)
+                          : $self->literal_value),
         );
     }
     elsif ($tc && $tc->isa('Moose::Meta::TypeConstraint::Class')) {

--- a/lib/Bread/Board/Declare/Role/Service.pm
+++ b/lib/Bread/Board/Declare/Role/Service.pm
@@ -36,8 +36,13 @@ around get => sub {
     }
 
     my $val = $self->$orig(@_);
-    $attr->verify_against_type_constraint($val, instance => $container)
-        if $attr->has_type_constraint;
+
+    if ($attr->has_type_constraint) {
+        $val = $attr->type_constraint->coerce($val)
+            if $attr->should_coerce;
+
+        $attr->verify_against_type_constraint($val, instance => $container);
+    }
 
     return $val;
 };

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -13,6 +13,7 @@ my $i;
 {
     package Foo;
     use Moose;
+    use Moose::Util::TypeConstraints;
     use Bread::Board::Declare;
 
     has foo => (
@@ -21,10 +22,14 @@ my $i;
         default => 'FOO',
     );
 
+    subtype 'ArrayRefOfStr', as 'ArrayRef[Str]';
+    coerce 'ArrayRefOfStr', from 'Str', via { [$_] };
+
     has bar => (
-        is    => 'ro',
-        isa   => 'Str',
-        value => 'BAR',
+        is     => 'ro',
+        isa    => 'ArrayRefOfStr',
+        coerce => 1,
+        value  => 'BAR',
     );
 
     has baz => (
@@ -62,7 +67,7 @@ $i = 0;
 {
     my $foo = Foo->new;
     is($foo->foo, 'FOO', "normal attrs work");
-    is($foo->bar, 'BAR', "literals work");
+    is_deeply($foo->bar, ['BAR'], "literals work");
     isa_ok($foo->baz, 'Baz');
     isnt($foo->baz, $foo->baz, "new instance each time");
     is($foo->quux, 'QUUX0', "block injections work");
@@ -78,7 +83,7 @@ $i = 0;
         quux => 'XUUQ',
     );
     is($foo->foo, 'OOF', "normal attrs work from constructor");
-    is($foo->bar, 'RAB', "constructor overrides literals");
+    is_deeply($foo->bar, ['RAB'], "constructor overrides literals");
     isa_ok($foo->baz, 'Baz');
     is($foo->baz, $baz, "constructor overrides constructor injections");
     is($foo->baz, $foo->baz, "and returns the same thing each time");

--- a/t/10-inlining.t
+++ b/t/10-inlining.t
@@ -14,7 +14,7 @@ use Test::More;
         accessor  => 'foo',
         predicate => 'has_foo',
         clearer   => 'clear_foo',
-        value     => 'foo',
+        value     => sub { 'foo' },
     );
 
     has bool => (


### PR DESCRIPTION
CodeRef values for literal values are allowed, but not handled anywhere. This
change fixes that, giving 'value' the same interface as 'default'.
