### PR TITLE
test predicates and clearers

### DIFF
--- a/t/predicates-and-clearers.t
+++ b/t/predicates-and-clearers.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Moose;
+use Scalar::Util 'refaddr';
+
+{
+    package Bar;
+    use Moose;
+}
+
+{
+    package Foo;
+    use Moose;
+    use Bread::Board::Declare;
+
+    has bar => (
+        isa          => 'Bar',
+		is           => 'ro',
+        lifecycle    => 'Singleton',
+		predicate    => 'has_bar',
+		clearer      => 'clear_bar',
+    );
+}
+
+with_immutable {
+    my $foo = Foo->new;
+    ok ! $foo->has_bar, 'does not have bar';
+	isa_ok my $inst0 = $foo->bar, 'Bar';
+	is refaddr( $inst0 ), refaddr( $foo->bar ), 'same instance';
+    ok $foo->has_bar, 'has bar';
+	$foo->clear_bar;
+    ok ! $foo->has_bar, 'does not have bar';
+	isnt refaddr( $inst0 ), refaddr( $foo->bar ), 'not the same instance';
+    ok $foo->has_bar, 'has bar';
+} 'Foo';
+
+done_testing;


### PR DESCRIPTION
predicates, and clearers do not work properly. This test demonstrates their failure. Expected behavior is a calling the clearer should have the effect that the singleton was never created and thus should attempt to create a new one. Being able to do this allows things like Unit's of Work, or request scope to be created easily.
